### PR TITLE
Feature: Reduce flicker at screen switch

### DIFF
--- a/src/components/ChooseableParticipant.tsx
+++ b/src/components/ChooseableParticipant.tsx
@@ -96,6 +96,7 @@ export const ChooseableParticipant = (props: ChooseableParticipantProps) => {
         isActivePlayer={isActivePlayer}
         roundsPlayed={roundsPlayed}
         videoPriority={props.isMainSpeaker ? 'high' : undefined}
+        videoOnly
       />
     </div>
   );

--- a/src/components/Layouts/GridVideoChatLayout.tsx
+++ b/src/components/Layouts/GridVideoChatLayout.tsx
@@ -3,7 +3,6 @@ import useVideoContext from 'hooks/useVideoContext/useVideoContext';
 import React from 'react';
 import useSessionContext from 'hooks/useSessionContext';
 import { ChooseableParticipant } from 'components/ChooseableParticipant';
-import { categorizeParticipants } from 'utils/participants';
 import { RevealedCard } from 'components/RevealedCard';
 import { nameFromIdentity } from 'utils/participants';
 import cn from 'classnames';

--- a/src/components/Layouts/GridVideoChatLayout.tsx
+++ b/src/components/Layouts/GridVideoChatLayout.tsx
@@ -33,14 +33,8 @@ const LetterInfo = (props: { participant: { identity: string }; isModerator?: bo
 export const GridVideoChatLayout = () => {
   const { room } = useVideoContext();
   const localParticipant = room!.localParticipant;
-  const participants = useParticipants();
-  const { resources, userGroup, moderators } = useSessionContext();
-
-  const { moderatorParitcipants, normalParticipants, speakerParticipants } = categorizeParticipants(
-    participants,
-    localParticipant,
-    moderators
-  );
+  const { moderatorParitcipants, normalParticipants, speakerParticipants } = useParticipants();
+  const { resources, userGroup } = useSessionContext();
 
   return (
     <div className="flex flex-col">
@@ -80,6 +74,15 @@ export const GridVideoChatLayout = () => {
       ) : null}
       <div className="w-full aspect-w-16 aspect-h-9">
         <div className="grid grid-cols-4 grid-rows-4 gap-2 justify-center items-center">
+          {moderatorParitcipants.slice(1).map(participant => (
+            <div key={participant.sid}>
+              <ChooseableParticipant
+                participant={participant}
+                isLocalParticipant={localParticipant.sid === participant.sid}
+              />
+            </div>
+          ))}
+
           {normalParticipants.map(participant => (
             <div key={participant.sid}>
               <ChooseableParticipant

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -3,7 +3,6 @@ import useParticipants from '../../hooks/useParticipants/useParticipants';
 import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 // import useSelectedParticipant from '../VideoProvider/useSelectedParticipant/useSelectedParticipant';
 // import useScreenShareParticipant from '../../hooks/useScreenShareParticipant/useScreenShareParticipant';
-import useSessionContext from 'hooks/useSessionContext';
 import { ChooseableParticipant, ChooseableParticipantProps } from 'components/ChooseableParticipant';
 import { nameFromIdentity, categorizeParticipants } from 'utils/participants';
 
@@ -19,16 +18,9 @@ const SmallParticipant = (props: ChooseableParticipantProps) => (
 export default function ParticipantList() {
   const { room } = useVideoContext();
   const localParticipant = room!.localParticipant;
-  const participants = useParticipants();
+  const { moderatorParitcipants, normalParticipants } = useParticipants();
   // const [selectedParticipant] = useSelectedParticipant();
   // const screenShareParticipant = useScreenShareParticipant();
-  const { moderators } = useSessionContext();
-
-  const { moderatorParitcipants, normalParticipants } = categorizeParticipants(
-    participants,
-    localParticipant,
-    moderators
-  );
 
   return (
     <div className="flex overflow-x-auto pr-5 pt-5 gap-x-5 bg-grayish pl-2">
@@ -48,8 +40,8 @@ export default function ParticipantList() {
           <SmallParticipant
             key={participant.sid}
             participant={participant}
-            // isSelected={participant === selectedParticipant}
             isLocalParticipant={localParticipant.sid === participant.sid}
+            // isSelected={participant === selectedParticipant}
           />
         );
       })}

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -4,7 +4,7 @@ import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 // import useSelectedParticipant from '../VideoProvider/useSelectedParticipant/useSelectedParticipant';
 // import useScreenShareParticipant from '../../hooks/useScreenShareParticipant/useScreenShareParticipant';
 import { ChooseableParticipant, ChooseableParticipantProps } from 'components/ChooseableParticipant';
-import { nameFromIdentity, categorizeParticipants } from 'utils/participants';
+import { nameFromIdentity } from 'utils/participants';
 
 const SmallParticipant = (props: ChooseableParticipantProps) => (
   <div className="w-40 relative flex flex-col">

--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -18,8 +18,7 @@ const PoweredByBar = () => (
 
 export default function Room() {
   const { activeScreen, userGroup } = useSessionContext();
-  const participants = useParticipants();
-  const { translatorParticipant } = categorizeParticipants(participants);
+  const { translatorParticipant, speakerParticipants } = useParticipants();
 
   const CurrentScreen = () => {
     if (activeScreen === ScreenType.Game) {
@@ -33,11 +32,13 @@ export default function Room() {
 
   return (
     <>
-      {userGroup === UserGroup.StreamServerTranslated && translatorParticipant ? (
-        <div className="fixed top-0 h-0 w-0">
+      <div className="fixed top-0 h-0 w-0">
+        {userGroup === UserGroup.StreamServerTranslated && translatorParticipant ? (
           <ParticipantTracks participant={translatorParticipant} audioOnly />
-        </div>
-      ) : null}
+        ) : (
+          speakerParticipants.map(part => <ParticipantTracks participant={part} audioOnly />)
+        )}
+      </div>
       <div className="flex flex-col h-screen">
         <div
           className="flex-grow flex"

--- a/src/hooks/useMainParticipant/useMainParticipant.tsx
+++ b/src/hooks/useMainParticipant/useMainParticipant.tsx
@@ -8,12 +8,18 @@ export default function useMainParticipant() {
   const [selectedParticipant] = useSelectedParticipant();
   const screenShareParticipant = useScreenShareParticipant();
   const dominantSpeaker = useDominantSpeaker();
-  const participants = useParticipants();
+  const { moderatorParitcipants } = useParticipants();
   const { room } = useVideoContext();
   const localParticipant = room?.localParticipant;
   const remoteScreenShareParticipant = screenShareParticipant !== localParticipant ? screenShareParticipant : null;
 
   // The participant that is returned is displayed in the main video area. Changing the order of the following
   // variables will change the how the main speaker is determined.
-  return selectedParticipant || remoteScreenShareParticipant || dominantSpeaker || participants[0] || localParticipant;
+  return (
+    selectedParticipant ||
+    remoteScreenShareParticipant ||
+    dominantSpeaker ||
+    moderatorParitcipants[0] ||
+    localParticipant
+  );
 }

--- a/src/hooks/useParticipants/useParticipants.tsx
+++ b/src/hooks/useParticipants/useParticipants.tsx
@@ -1,12 +1,16 @@
+import useSessionContext from 'hooks/useSessionContext';
 import { useEffect, useState } from 'react';
 import { RemoteParticipant } from 'twilio-video';
+import { categorizeParticipants } from 'utils/participants';
 // import useDominantSpeaker from '../useDominantSpeaker/useDominantSpeaker';
 import useVideoContext from '../useVideoContext/useVideoContext';
 
 export default function useParticipants() {
   const { room } = useVideoContext();
-  // const dominantSpeaker = useDominantSpeaker();
   const [participants, setParticipants] = useState(Array.from(room?.participants.values() ?? []));
+  const { moderators } = useSessionContext();
+  const localParticipant = room!.localParticipant;
+  // const dominantSpeaker = useDominantSpeaker();
 
   // When the dominant speaker changes, they are moved to the front of the participants array.
   // This means that the most recent dominant speakers will always be near the top of the
@@ -35,5 +39,5 @@ export default function useParticipants() {
     }
   }, [room]);
 
-  return participants;
+  return { ...categorizeParticipants(participants, localParticipant, moderators) };
 }

--- a/src/hooks/useParticipants/useParticipants.tsx
+++ b/src/hooks/useParticipants/useParticipants.tsx
@@ -39,5 +39,5 @@ export default function useParticipants() {
     }
   }, [room]);
 
-  return { ...categorizeParticipants(participants, localParticipant, moderators) };
+  return { ...categorizeParticipants(participants, localParticipant, moderators), localParticipant };
 }


### PR DESCRIPTION
I split up video and audio streams, so that I can have the audio streams permanently mounted even during screen switch. 

That means that the audio is now consistently playing during the process of switching from the grid video layout to the game screen.